### PR TITLE
Specify pipeline version in bioconda env name

### DIFF
--- a/{{cookiecutter.pipeline_slug}}/Dockerfile
+++ b/{{cookiecutter.pipeline_slug}}/Dockerfile
@@ -5,4 +5,4 @@ LABEL authors="{{ cookiecutter.author_email }}" \
 
 COPY environment.yml /
 RUN conda env create -f /environment.yml && conda clean -a
-ENV PATH /opt/conda/envs/{{ cookiecutter.pipeline_slug }}/bin:$PATH
+ENV PATH /opt/conda/envs/{{ cookiecutter.pipeline_slug }}-{{ cookiecutter.version }}/bin:$PATH

--- a/{{cookiecutter.pipeline_slug}}/environment.yml
+++ b/{{cookiecutter.pipeline_slug}}/environment.yml
@@ -1,4 +1,4 @@
-name: {{ cookiecutter.pipeline_slug }}
+name: {{ cookiecutter.pipeline_slug }}-{{ cookiecutter.version }}
 channels:
   - defaults
   - conda-forge


### PR DESCRIPTION
Add the version number to the bioconda env name. This makes it clearer when listing environments and makes it less likely that people will forget to use the most up to date environment.