### PR TITLE
Remove conda conda-forge::openjdk dependency

### DIFF
--- a/{{cookiecutter.pipeline_slug}}/environment.yml
+++ b/{{cookiecutter.pipeline_slug}}/environment.yml
@@ -4,6 +4,5 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - conda-forge::openjdk=8.0.144  # Needed for FastQC docker - see bioconda/bioconda-recipes#5026
   - fastqc=0.11.7
   - multiqc=1.5


### PR DESCRIPTION
The bioconda FastQC recipe has been fixed, so the conda-forge specific dependency is no longer required. See https://github.com/bioconda/bioconda-recipes/pull/8588